### PR TITLE
🐛 Pillow bugs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ dependencies = [
   "rich-click~=1.5.2",
   "rich-pixels~=2.1.1",
   "textual~=0.22.3",
-  "universal-pathlib~=0.0.21"
+  "universal-pathlib~=0.0.21",
+  "Pillow~=9.1.0"
 ]
 description = "TUI File Browser App"
 dynamic = ["version"]


### PR DESCRIPTION
A problem in rich-pixels caused this error `ImportError: cannot import name 'Resampling' from 'PIL.Image'` this commit fixes it by requiring Pillow `Pillow>=9.1.0`